### PR TITLE
update to 2.6.1

### DIFF
--- a/Cheffile
+++ b/Cheffile
@@ -4,8 +4,7 @@
 site 'http://community.opscode.com/api/v1'
 
 cookbook 'ark'
-cookbook "composer",
-  :git => "git://github.com/Morphodo/chef-composer.git"
+cookbook "composer"
 
 # development
 cookbook 'simplelog_handler'

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -1,6 +1,7 @@
 SITE
   remote: http://community.opscode.com/api/v1
   specs:
+    apt (6.1.0)
     ark (3.0.0)
       build-essential (>= 0.0.0)
       seven_zip (>= 0.0.0)
@@ -8,21 +9,29 @@ SITE
     build-essential (8.0.1)
       mingw (>= 1.1)
       seven_zip (>= 0.0.0)
+    compat_resource (12.19.0)
+    composer (2.6.0)
+      apt (>= 0.0.0)
+      php (>= 0.0.0)
+      windows (>= 0.0.0)
     mingw (2.0.0)
       seven_zip (>= 0.0.0)
+    mysql (8.3.1)
     ohai (5.0.3)
+    php (4.0.0)
+      build-essential (>= 0.0.0)
+      mysql (>= 6.0.0)
+      xml (>= 0.0.0)
+      yum-epel (>= 0.0.0)
     seven_zip (2.0.2)
       windows (>= 1.2.2)
     simplelog_handler (1.0.0)
     windows (3.0.5)
       ohai (>= 4.0.0)
-
-GIT
-  remote: git://github.com/Morphodo/chef-composer.git
-  ref: master
-  sha: 92aee6313fc47dfd51b45c176b7efe41c767c57d
-  specs:
-    composer (0.2.1)
+    xml (3.1.1)
+      build-essential (>= 0.0.0)
+    yum-epel (2.1.1)
+      compat_resource (>= 12.16.3)
 
 DEPENDENCIES
   ark (>= 0)

--- a/Cheffile.lock
+++ b/Cheffile.lock
@@ -1,15 +1,21 @@
 SITE
   remote: http://community.opscode.com/api/v1
   specs:
-    7-zip (1.0.2)
-      windows (>= 1.2.2)
-    ark (0.9.0)
-      7-zip (>= 0.0.0)
+    ark (3.0.0)
+      build-essential (>= 0.0.0)
+      seven_zip (>= 0.0.0)
       windows (>= 0.0.0)
-    chef_handler (1.1.8)
+    build-essential (8.0.1)
+      mingw (>= 1.1)
+      seven_zip (>= 0.0.0)
+    mingw (2.0.0)
+      seven_zip (>= 0.0.0)
+    ohai (5.0.3)
+    seven_zip (2.0.2)
+      windows (>= 1.2.2)
     simplelog_handler (1.0.0)
-    windows (1.37.0)
-      chef_handler (>= 0.0.0)
+    windows (3.0.5)
+      ohai (>= 4.0.0)
 
 GIT
   remote: git://github.com/Morphodo/chef-composer.git

--- a/Vagrantfile
+++ b/Vagrantfile
@@ -33,10 +33,11 @@ Vagrant.configure(VAGRANTFILE_API_VERSION) do |config|
     aws.region = ENV['AWS_REGION']
     aws.instance_type = 'c3.large'
     case ENV['AWS_REGION']
+    # Amazon Linux AMI 2017.03.0 (HVM), SSD Volume Type
     when 'ap-northeast-1'
-      aws.ami = 'ami-0c11b26d' # Amazon Linux AMI 2016.09.0 (HVM), SSD Volume Type
+      aws.ami = 'ami-923d12f5'
     when 'us-east-1'
-      aws.ami = 'ami-b73b63a0' # Amazon Linux AMI 2016.09.0 (HVM), SSD Volume Type
+      aws.ami = 'ami-c58c1dd3'
     else
       raise "Unsupported region #{ENV['AWS_REGION']}"
     end

--- a/product_version
+++ b/product_version
@@ -1,1 +1,1 @@
-export PRODUCT_VERSION='2.0.1-5'
+export PRODUCT_VERSION='2.7.1-1'

--- a/site-cookbooks/mautic/attributes/defaults.rb
+++ b/site-cookbooks/mautic/attributes/defaults.rb
@@ -3,8 +3,8 @@ default[:lw1_mautic][:group] = 'apache'
 
 ## Sum = Sha256
 default[:lw1_mautic][:install] = {
-  version: '2.7.1',
-  checksum: "216c46db975ba039c7d301296c8e6ad4d1036fe598219840ab7f70fc52f3bd7c",
+  version: '2.6.1',
+  checksum: "364c3ea010f77a4b44ac1ab472a6fc7e6074980e7ab4d036dd6aa54c96ecca29",
   base_url: "https://github.com/mautic/mautic/archive/"
 }
 

--- a/site-cookbooks/mautic/attributes/defaults.rb
+++ b/site-cookbooks/mautic/attributes/defaults.rb
@@ -3,8 +3,8 @@ default[:lw1_mautic][:group] = 'apache'
 
 ## Sum = Sha256
 default[:lw1_mautic][:install] = {
-  version: '2.0.1',
-  checksum: "3dc5e11e3fcd09584e8058c713290c62d2380f18519c08eee3adcd846f04324d",
+  version: '2.7.1',
+  checksum: "216c46db975ba039c7d301296c8e6ad4d1036fe598219840ab7f70fc52f3bd7c",
   base_url: "https://github.com/mautic/mautic/archive/"
 }
 

--- a/site-cookbooks/mautic/files/default/fixtures/2.6.1/LoadUserData.php.erb
+++ b/site-cookbooks/mautic/files/default/fixtures/2.6.1/LoadUserData.php.erb
@@ -1,0 +1,68 @@
+<?php
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
+ * @author      Mautic
+ *
+ * @link        http://mautic.org
+ *
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Mautic\UserBundle\Entity\User;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+
+/**
+ * Class LoadUserData.
+ */
+class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
+{
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        $user = new User();
+        $user->setFirstName('Admin');
+        $user->setLastName('User');
+        $user->setUsername('admin');
+        $user->setEmail('admin@mautic.amiage.com');
+        $encoder = $this->container
+            ->get('security.encoder_factory')
+            ->getEncoder($user)
+        ;
+        $user->setPassword($encoder->encodePassword('mautic', $user->getSalt()));
+        $user->setRole($this->getReference('admin-role'));
+        $manager->persist($user);
+        $manager->flush();
+
+        $this->addReference('admin-user', $user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 2;
+    }
+}

--- a/site-cookbooks/mautic/files/default/fixtures/2.7.1/LoadUserData.php.erb
+++ b/site-cookbooks/mautic/files/default/fixtures/2.7.1/LoadUserData.php.erb
@@ -1,9 +1,11 @@
 <?php
-/**
- * @package     Mautic
- * @copyright   2014 Mautic Contributors. All rights reserved.
+
+/*
+ * @copyright   2014 Mautic Contributors. All rights reserved
  * @author      Mautic
+ *
  * @link        http://mautic.org
+ *
  * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
  */
 
@@ -12,16 +14,15 @@ namespace Mautic\UserBundle\DataFixtures\ORM;
 use Doctrine\Common\DataFixtures\AbstractFixture;
 use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
 use Doctrine\Common\Persistence\ObjectManager;
+use Mautic\UserBundle\Entity\User;
 use Symfony\Component\DependencyInjection\ContainerAwareInterface;
 use Symfony\Component\DependencyInjection\ContainerInterface;
-use Mautic\UserBundle\Entity\User;
 
 /**
- * Class LoadUserData
+ * Class LoadUserData.
  */
 class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
 {
-
     /**
      * @var ContainerInterface
      */

--- a/site-cookbooks/mautic/files/default/fixtures/2.7.1/LoadUserData.php.erb
+++ b/site-cookbooks/mautic/files/default/fixtures/2.7.1/LoadUserData.php.erb
@@ -1,0 +1,67 @@
+<?php
+/**
+ * @package     Mautic
+ * @copyright   2014 Mautic Contributors. All rights reserved.
+ * @author      Mautic
+ * @link        http://mautic.org
+ * @license     GNU/GPLv3 http://www.gnu.org/licenses/gpl-3.0.html
+ */
+
+namespace Mautic\UserBundle\DataFixtures\ORM;
+
+use Doctrine\Common\DataFixtures\AbstractFixture;
+use Doctrine\Common\DataFixtures\OrderedFixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Symfony\Component\DependencyInjection\ContainerAwareInterface;
+use Symfony\Component\DependencyInjection\ContainerInterface;
+use Mautic\UserBundle\Entity\User;
+
+/**
+ * Class LoadUserData
+ */
+class LoadUserData extends AbstractFixture implements OrderedFixtureInterface, ContainerAwareInterface
+{
+
+    /**
+     * @var ContainerInterface
+     */
+    private $container;
+
+    /**
+     * {@inheritdoc}
+     */
+    public function setContainer(ContainerInterface $container = null)
+    {
+        $this->container = $container;
+    }
+
+    /**
+     * @param ObjectManager $manager
+     */
+    public function load(ObjectManager $manager)
+    {
+        $user = new User();
+        $user->setFirstName('Admin');
+        $user->setLastName('User');
+        $user->setUsername('admin');
+        $user->setEmail('admin@mautic.amiage.com');
+        $encoder = $this->container
+            ->get('security.encoder_factory')
+            ->getEncoder($user)
+        ;
+        $user->setPassword($encoder->encodePassword('mautic', $user->getSalt()));
+        $user->setRole($this->getReference('admin-role'));
+        $manager->persist($user);
+        $manager->flush();
+
+        $this->addReference('admin-user', $user);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function getOrder()
+    {
+        return 2;
+    }
+}

--- a/site-cookbooks/mautic/templates/default/tasks/first_boot.erb
+++ b/site-cookbooks/mautic/templates/default/tasks/first_boot.erb
@@ -2,7 +2,7 @@ require 'base64'
 
 def adjust_location
   location = {}
-  case node.ec2.placement_availability_zone
+  case node[:ec2][:placement_availability_zone]
   when /^ap-northeast/
     location[:lang] = "ja"
     location[:zone] = "Asia/Tokyo"
@@ -31,10 +31,10 @@ bash 'mysql_secure_install emulate' do
     /usr/bin/mysqladmin drop test -f
     /usr/bin/mysql -e "DELETE FROM user WHERE user = '';" -D mysql
     /usr/bin/mysql -e "DELETE FROM mysql.user WHERE User='root' AND Host NOT IN ('localhost', '127.0.0.1', '::1');" -D mysql
-    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'::1' = PASSWORD('#{node.ec2.instance_id}');" -D mysql
-    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'127.0.0.1' = PASSWORD('#{node.ec2.instance_id}');" -D mysql
-    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('#{node.ec2.instance_id}');" -D mysql
-    /usr/bin/mysqladmin flush-privileges -pnewpassword -p#{node.ec2.instance_id}
+    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'::1' = PASSWORD('#{node[:ec2][:instance_id]}');" -D mysql
+    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'127.0.0.1' = PASSWORD('#{node[:ec2][:instance_id]}');" -D mysql
+    /usr/bin/mysql -e "SET PASSWORD FOR 'root'@'localhost' = PASSWORD('#{node[:ec2][:instance_id]}');" -D mysql
+    /usr/bin/mysqladmin flush-privileges -pnewpassword -p#{node[:ec2][:instance_id]}
   EOH
   action :run
   only_if "/usr/bin/mysql -u root -e 'show databases;'"

--- a/site-cookbooks/mautic/templates/default/tasks/first_boot.erb
+++ b/site-cookbooks/mautic/templates/default/tasks/first_boot.erb
@@ -79,8 +79,8 @@ bash 'install mautic by doctrine' do
     /usr/bin/php app/console doctrine:database:create --env=prod --no-interaction
     /usr/bin/php app/console doctrine:migrations:status --env=prod --no-interaction
     /usr/bin/php app/console doctrine:schema:create --env=prod --no-interaction
-    /usr/bin/php app/console doctrine:fixtures:load --env=prod --fixtures=app/bundles/InstallBundle/InstallFixtures/ --no-interaction
     /usr/bin/php app/console doctrine:migrations:migrate --env=prod --no-interaction
+    /usr/bin/php app/console doctrine:fixtures:load --env=prod --append --fixtures=app/bundles/InstallBundle/InstallFixtures/ --no-interaction
     /usr/bin/php /var/www/html/app/console mautic:iplookup:download --env=prod --no-interaction
     touch /var/www/html/.fixtures_done
   EOH


### PR DESCRIPTION
related: #4 

- remove outdated (~chef12) syntax (`node.ec2.foo.bar`)
- replace outdated composer cookbook
- update base AMI to 2017.03
